### PR TITLE
Add GitHub Skills activity (Fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR implements the missing GitHub Skills activity requested in issue #6.

## Changes Made
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Configured with appropriate schedule (Mondays and Fridays, 3:30 PM - 4:30 PM)
- Set maximum participants to 25 to accommodate high interest
- Added description highlighting connection to GitHub Certifications program

## Addresses Issue
Fixes #6 - Students can now sign up for the GitHub Skills activity that was announced by the principal.

## Testing
- [x] Activity appears in the activities list
- [x] Follows same structure as existing activities
- [x] Ready for student registration

This resolves the urgent request from student "Hewbie C." and enables students to register for the GitHub partnership program before the deadline.